### PR TITLE
Alter blog and Dockerfile to support running on resin

### DIFF
--- a/.dockerenv
+++ b/.dockerenv
@@ -1,0 +1,4 @@
+GHOST_URL=http://localhost:2368/blog
+GHOST_PORT=2368
+GHOST_SQLITE_PATH=content/data/ghost.db
+GHOST_DATA_PATH=content

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,6 @@ npm-debug.log
 *.swo
 *.swp
 .git
+/content/data/*.json
+.idea
+.dockerenv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM library/node:4.2
+FROM library/node:4.6
 
-EXPOSE 2368
+ENV NODE_ENV production
+ENTRYPOINT ["/usr/local/bin/pm2"]
+CMD ["start", "--no-daemon", "--name", "ghost", "index.js"]
 
-WORKDIR /usr/src/app
+RUN npm install -g pm2
 
-COPY package.json ./.
-COPY core ./core
+WORKDIR /usr/local/src/app
+COPY package.json .
 RUN npm install --unsafe-perm --production \
 	&& npm cache clean
 
 COPY . .
 
-ENTRYPOINT ["/usr/local/bin/npm"]
-CMD ["start", "--production"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+IMAGE=localhost/resin-blog:latest
+
+build:
+	docker build -t ${IMAGE} .
+
+run: build
+	docker run -it --rm -p 2368:2368 \
+		--env-file .dockerenv \
+		${IMAGE}
+
+shell: build
+	docker run -it --rm -p 2368:2368 \
+		--env-file .dockerenv \
+		--entrypoint /bin/bash \
+		${IMAGE}
+
+exec:
+	docker exec -it $$(docker ps | grep "${IMAGE}" | cut -f 1 -d ' ') /bin/bash
+

--- a/config.js
+++ b/config.js
@@ -2,167 +2,49 @@
 // Setup your Ghost install for various environments
 
 var path = require('path'),
-    config;
+    config,
+    dbConfig
+    ;
 
-config = {
-    // ### Development **(default)**
-    development: {
-        // The url to use when providing links to the site, E.g. in RSS and email.
-        url: 'http://0.0.0.0:2368/',
-
-        // Example mail config
-        // Visit http://docs.ghost.org/mail for instructions
-        // ```
-        //  mail: {
-        //      transport: 'SMTP',
-        //      options: {
-        //          service: 'Mailgun',
-        //          auth: {
-        //              user: '', // mailgun username
-        //              pass: ''  // mailgun password
-        //          }
-        //      }
-        //  },
-        // ```
-
-        database: {
-            client: 'sqlite3',
-            connection: {
-                filename: path.join(__dirname, '/content/data/ghost-dev.db')
-            },
-            debug: false
-        },
-        server: {
-            // Host to be passed to node's `net.Server#listen()`
-            host: '0.0.0.0',
-            // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
-            port: '2368'
-        },
-        paths: {
-          contentPath: path.join(__dirname, 'content'),
+if (process.env.GHOST_DB_ENGINE === "mysql") {
+    dbConfig = {
+        client: 'mysql',
+        connection: {
+            host     : process.env.GHOST_DB_HOST,
+            port     : process.env.GHOST_DB_PORT,
+            user     : process.env.GHOST_DB_USER,
+            password : process.env.GHOST_DB_PASSWORD,
+            database : process.env.GHOST_DB_NAME,
+            charset  : 'utf8'
         }
+    };
+} else {
+    dbConfig = {
+        client: 'sqlite3',
+        connection: {
+            filename: process.env.GHOST_SQLITE_PATH
+        },
+        debug: false
+    };
+}
+
+ghostConfig = {
+        url: process.env.GHOST_URL,
+    paths: {
+        contentPath: process.env.GHOST_DATA_PATH
     },
-
-    staging: {
-        url: 'http://resin.io/staging-blog/',
-        mail: {},
-        database: {
-            client: 'sqlite3',
-            connection: {
-                filename: path.join(__dirname, '/content/data/ghost.db')
-            },
-            debug: false
-        },
-        server: {
-            // Host to be passed to node's `net.Server#listen()`
-            host: '0.0.0.0',
-            // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
-            port: '2369'
-        },
-        paths: {
-          contentPath: path.join(__dirname, 'content'),
-        }
-    },
-
-    // ### Production
-    // When running Ghost in the wild, use the production environment
-    // Configure your URL and mail settings here
-    production: {
-        url: 'http://resin.io/blog/',
-        mail: {},
-        database: {
-            client: 'sqlite3',
-            connection: {
-                filename: path.join(__dirname, '/content/data/ghost.db')
-            },
-            debug: false
-        },
-        server: {
-            // Host to be passed to node's `net.Server#listen()`
-            host: '0.0.0.0',
-            // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
-            port: '2368'
-        },
-        paths: {
-          contentPath: path.join(__dirname, 'content'),
-        }
-    },
-
-    // **Developers only need to edit below here**
-
-    // ### Testing
-    // Used when developing Ghost to run tests and check the health of Ghost
-    // Uses a different port number
-    testing: {
-        url: 'http://127.0.0.1:2369',
-        database: {
-            client: 'sqlite3',
-            connection: {
-                filename: path.join(__dirname, '/content/data/ghost-test.db')
-            }
-        },
-        server: {
-            host: '127.0.0.1',
-            port: '2369'
-        }
-    },
-
-    // ### Travis
-    // Automated testing run through GitHub
-    'travis-sqlite3': {
-        url: 'http://127.0.0.1:2369',
-        database: {
-            client: 'sqlite3',
-            connection: {
-                filename: path.join(__dirname, '/content/data/ghost-travis.db')
-            }
-        },
-        server: {
-            host: '127.0.0.1',
-            port: '2369'
-        }
-    },
-
-    // ### Travis
-    // Automated testing run through GitHub
-    'travis-mysql': {
-        url: 'http://127.0.0.1:2369',
-        database: {
-            client: 'mysql',
-            connection: {
-                host     : '127.0.0.1',
-                user     : 'travis',
-                password : '',
-                database : 'ghost_travis',
-                charset  : 'utf8'
-            }
-        },
-        server: {
-            host: '127.0.0.1',
-            port: '2369'
-        }
-    },
-
-    // ### Travis
-    // Automated testing run through GitHub
-    'travis-pg': {
-        url: 'http://127.0.0.1:2369',
-        database: {
-            client: 'pg',
-            connection: {
-                host     : '127.0.0.1',
-                user     : 'postgres',
-                password : '',
-                database : 'ghost_travis',
-                charset  : 'utf8'
-            }
-        },
-        server: {
-            host: '127.0.0.1',
-            port: '2369'
-        }
+    mail: {},
+    database: dbConfig,
+    server: {
+        // Host to be passed to node's `net.Server#listen()`
+        host: '0.0.0.0',
+        // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
+        port: process.env.GHOST_PORT
     }
 };
 
+config = { production: ghostConfig, development: ghostConfig };
+
 // Export config
 module.exports = config;
+

--- a/content/themes/resin/partials/navigation.hbs
+++ b/content/themes/resin/partials/navigation.hbs
@@ -7,8 +7,8 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="https://resin.io">
-        <img src="{{asset "/images/logo-right.png"}}" alt="resin.io" />
+      <a class="navbar-brand" href="{{@blog.url}}">
+        <img src="{{asset "/images/logo-right.png"}}" alt="resin.io blog" />
       </a>
     </div>
     <div class="collapse navbar-collapse" id="main-nav">

--- a/index.js
+++ b/index.js
@@ -1,11 +1,15 @@
 // # Ghost Startup
 const ghost = require('ghost');
 const path = require('path');
+const express = require('express');
+
+const expressInstance = express();
 
 ghost({
   config: path.join(__dirname, 'config.js')
 }).then(function (ghostServer) {
-  ghostServer.start();
+  expressInstance.use(ghostServer.config.paths.subdir, ghostServer.rootApp);
+  ghostServer.start(expressInstance);
 }).catch(function(err) {
   console.error(err);
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "resin.io's blog",
   "main": "index.js",
   "dependencies": {
-    "ghost": "^0.11.4"
+    "ghost": "^0.11.4",
+    "express": "^4.14.1"
   },
   "scripts": {
     "start": "node index.js"


### PR DESCRIPTION
This change mostly does the following things:

1. Support configuring the database connection in production using
environment variables, including switching to mysql
2. Modify links so that they don't have hardcoded paths. This allows
running the same codebase in multiple environments, and merging them
together cleanly as improvements are deemed ready for production

Connects to #18